### PR TITLE
feat: add PR preview deployment workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,78 @@
+name: pr-preview
+on:
+  pull_request_target:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check-permissions:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/deploy-preview'))
+    outputs:
+      allowed: ${{ steps.check-team.outputs.allowed }}
+      pr-number: ${{ steps.check-team.outputs.number }}
+    steps:
+      - name: Get PR info and check permissions
+        id: check-team
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          COMMENT_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$PR_ASSOCIATION"
+          else
+            echo "number=$COMMENT_NUMBER" >> $GITHUB_OUTPUT
+            ASSOCIATION="$COMMENT_ASSOCIATION"
+          fi
+
+          if [[ "$ASSOCIATION" == "OWNER" || "$ASSOCIATION" == "MEMBER" || "$ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            echo "User is a repo $ASSOCIATION — allowed"
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+            echo "User association is $ASSOCIATION — not allowed"
+          fi
+
+  deploy-preview:
+    runs-on: ubuntu-latest
+    needs: check-permissions
+    if: needs.check-permissions.outputs.allowed == 'true'
+    env:
+      SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      GH_PR_TOKEN: ${{ secrets.GH_PR_TOKEN }}
+      GH_PR_NUM: ${{ needs.check-permissions.outputs.pr-number }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git fetch origin pull/$GH_PR_NUM/head:tmp
+          git checkout tmp
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/cache@v4
+        id: yarn-cache
+        name: Cache yarn deps
+        with:
+          path: |
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-yarn-22-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - run: yarn build
+        name: Build
+      - run: yarn build:docs
+        name: Build docs
+      - name: Upload docs
+        uses: patternfly/.github/.github/actions/surge-preview@main
+        with:
+          folder: packages/module/public


### PR DESCRIPTION
Adds a pr-preview workflow that builds and publishes docs to Surge for PR previews. The workflow is separate from check-pr to avoid re-running tests — it only handles preview deployment.

Previews are published when a team member (OWNER/MEMBER/COLLABORATOR) opens a PR, or when a team member comments `/deploy-preview` on a PR.